### PR TITLE
Present language switcher text in target language.

### DIFF
--- a/app/views/shared/_language.html.erb
+++ b/app/views/shared/_language.html.erb
@@ -1,9 +1,9 @@
 <div class="container mt-1">
   <div class="row justify-content-end">
     <div class="btn-group" role="group" aria-label="Basic example">
-      <%= link_to t("locales.en"), appointments_path(locale: ""),
+      <%= link_to "English", appointments_path(locale: ""),
           class: "btn btn-sm btn-primary #{locale == :en ? "disabled" : ""}" %>
-      <%= link_to t("locales.fr"), appointments_path(locale: :fr),
+      <%= link_to "Français", appointments_path(locale: :fr),
           class: "btn btn-sm btn-primary #{locale == :fr ? "disabled" : ""}" %>
     </div>
   </div>


### PR DESCRIPTION
Best practice dictates that language pickers should use the language of the target audience.

This PR uses hard-coded button labels rather than using I18n.